### PR TITLE
UserAgent exposed for HTTP requests

### DIFF
--- a/MavenNet.Tests/MavenNet.Tests.csproj
+++ b/MavenNet.Tests/MavenNet.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net6;net7</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/MavenNet.Tests/Test.cs
+++ b/MavenNet.Tests/Test.cs
@@ -104,9 +104,8 @@ namespace MavenNet.Tests
         [Fact]
         public async Task Test_GroupIds_Project_MAVENCENTRAL_1()
         {
-            MavenRepository.HttpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36");
-
             var repo = MavenRepository.FromMavenCentral();
+            MavenRepository.HttpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36");
             await repo.Refresh("com.google.accompanist");
 
             var project = await repo.GetProjectAsync("com.google.accompanist", "accompanist-appcompat-theme", "0.30.1");

--- a/MavenNet.Tests/Test.cs
+++ b/MavenNet.Tests/Test.cs
@@ -100,5 +100,36 @@ namespace MavenNet.Tests
 
 			Assert.True(project.Dependencies?.Any());
 		}
-	}
+
+        [Fact]
+        public async Task Test_GroupIds_Project_MAVENCENTRAL_1()
+        {
+            MavenRepository.HttpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36");
+
+            var repo = MavenRepository.FromMavenCentral();
+            await repo.Refresh("com.google.accompanist");
+
+            var project = await repo.GetProjectAsync("com.google.accompanist", "accompanist-appcompat-theme", "0.30.1");
+
+            Assert.True(project != null);
+
+            Assert.True(project.Dependencies?.Any());
+        }
+
+        [Fact]
+        public async Task Test_GroupIds_Project_MAVENCENTRAL_2()
+        {
+            var repo = MavenRepository.FromMavenCentral();
+            MavenRepository.HttpClient.DefaultRequestHeaders.Clear();
+            await repo.Refresh("com.google.accompanist");
+
+            try
+            {
+                var project = await repo.GetProjectAsync("com.google.accompanist", "accompanist-appcompat-theme", "0.30.1");
+            }
+            finally
+            {
+            }
+        }
+    }
 }

--- a/MavenNet/MavenCentralRepository.cs
+++ b/MavenNet/MavenCentralRepository.cs
@@ -19,15 +19,16 @@ namespace MavenNet
             return string.Join(new string(PathSeparator, 1), parts);
         }
 
-        static readonly HttpClient http = new HttpClient();
-
         protected override async Task<IEnumerable<Artifact>> GetArtifactsAsync(string groupId)
         {
             var artifacts = new List<Artifact>();
 
             var url = $"http://search.maven.org/solrsearch/select?q=g:%22{groupId}%22&rows=100&wt=json";
 
-            var data = await http.GetStringAsync(url);
+            // enable by default?
+            // HttpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36");
+
+            var data = await HttpClient.GetStringAsync(url);
 
             var json = JObject.Parse(data);
 
@@ -83,7 +84,7 @@ namespace MavenNet
         {
             var url = $"https://repo1.maven.org/maven2/{path}";
 
-            return http.GetStreamAsync(url);
+            return HttpClient.GetStreamAsync(url);
         }
     }
 }

--- a/MavenNet/MavenNet.csproj
+++ b/MavenNet/MavenNet.csproj
@@ -28,7 +28,7 @@
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NuGet.Versioning" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/MavenNet/MavenRepository.cs
+++ b/MavenNet/MavenRepository.cs
@@ -4,11 +4,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using MavenNet.Models;
+using System.Net.Http;
 
 namespace MavenNet
 {
     public abstract class MavenRepository : IMavenRepository
     {
+        public static readonly HttpClient HttpClient = new HttpClient();
+
         public static GoogleMavenRepository FromGoogle()
         {
             return new GoogleMavenRepository();


### PR DESCRIPTION
Seems like HttpClient has problems, in some cases, with getting info from Maven repositories.

NOTE[s]: 

-   never experienced this error from local Mac builds
-   the problem was detected on CI/CD servers during `binderator` runs:

```
Unhandled exception. System.Collections.Generic.KeyNotFoundException: No version for artifact `accompanist-placeholder-material` with version: `0.30.1`
   at MavenNet.MavenRepository.GetProjectAsync(String groupId, String artifactId, String version)
   at AndroidBinderator.Engine.ProcessConfig(BindingConfig config) in D:\a\_work\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 65
   at AndroidBinderator.Engine.BinderateAsync(BindingConfig config) in D:\a\_work\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 46
   at Xamarin.AndroidBinderator.Tool.Program.Main(String[] args) in D:\a\_work\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator.Tool\Program.cs:line 67
   at Xamarin.AndroidBinderator.Tool.Program.<Main>(String[] args)
An error occurred when executing task 'binderate'.
Error: Process xamarin-android-binderator exited with code 134.
```

mavenNet error after adding unit-test case reveals true cause of the exception/error:

```
[xUnit.net 00:00:02.12]       
    System.Net.Http.HttpRequestException : 
    Response status code does not indicate success: 403 (Forbidden).
```

Error/exception occurs ONLY for SOME artifacts (`gropuId`) - in this case `com.google.accompanist` group.

Artifacts (repro data - urls) causing exception:

```
    com.google.accompanist:accompanist-appcompat-theme:0.30.1
    com.google.accompanist:accompanist-placeholder-material:0.30.1
```

The reason for failures for SOME artifacts, could be behind reverse proxy and database shardening 
and requests hitting HTTP server[s] for those specific packages.

The solution is to add `User-Agent` to requests, so `HttpClient` was exposed, so headers can be 
manipulated.