### PR TITLE
Include MavenNet.pdb in the NuGet package.

### DIFF
--- a/MavenNet/MavenNet.csproj
+++ b/MavenNet/MavenNet.csproj
@@ -18,6 +18,8 @@
     <PackageTags>Maven</PackageTags>
     <Authors>Redth</Authors>
     <Owners>Redth</Owners>
+    <!-- Include symbol files (*.pdb) in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">


### PR DESCRIPTION
.NET Android team is building new features that use MavenNet.  In order to pass MS internal shipping checks, `MavenNet.pdb` will be required.  Place this file in the NuGet package so it will be available.