### PR TITLE
Make `Artifact.Repository` setter `public`.

### DIFF
--- a/MavenNet/Models/Artifact.cs
+++ b/MavenNet/Models/Artifact.cs
@@ -19,7 +19,7 @@ namespace MavenNet.Models
 		public string Id { get; private set; }
 		public IList<string> Versions { get; private set; }
 
-		public MavenRepository Repository { get; internal set; }
+		public MavenRepository Repository { get; set; }
 
 		public async Task<Models.Metadata> GetMetadata ()
 		{


### PR DESCRIPTION
We need to be able to manually set the `Repository` on an `Artifact`.  Make the setter `public` so it can be called.