### PR TITLE
Manual updates 20240807 support for nonstandard maven versions

### DIFF
--- a/MavenNet.Tests/MavenNet.Tests.csproj
+++ b/MavenNet.Tests/MavenNet.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/MavenNet.Tests/MavenVersioningTests.cs
+++ b/MavenNet.Tests/MavenVersioningTests.cs
@@ -18,6 +18,14 @@ namespace MavenNet.Tests
 		[InlineData("(,1.0],[1.2,)", "1.2", true)]
 		[InlineData("(,1.0],[1.2,)", "1.3", true)]
 		[InlineData("(,1.0],[1.2,)", "1.1", false)]
+		[InlineData("(,1.0],[2.2,)", "1.0.1.262e11d", false)]
+		[InlineData("(,0.8],[2.2,)", "0.11.1.647c3c2", false)]
+		[InlineData("(,0.8],[2.2,)", "0.11.1.3c786d2", false)]
+		[InlineData("(,0.8],[2.2,)", "0.10.1.2e8fe11", false)]
+		[InlineData("(,0.8],[2.2,)", "0.10.1.e92f734", false)]
+		[InlineData("(,0.8],[2.2,)", "0.10.1.d22d4de", false)]
+		[InlineData("(,0.8],[2.2,)", "0.9.3.545a756", false)]
+		[InlineData("(,0.8],[2.2,)", "0.9.3.a319893", false)]
 		public void Satisfy_Versions(string range, string version, bool satisfies)
 		{
 			var mvr = new MavenVersionRange(range);

--- a/MavenNet/MavenNet.csproj
+++ b/MavenNet/MavenNet.csproj
@@ -30,7 +30,7 @@
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Versioning" Version="5.9.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NuGet.Versioning" Version="6.10.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context:

MAUI for Android cannot load images in AVIF format/encoding.

https://github.com/dotnet/maui/issues/23316

https://en.wikipedia.org/wiki/AVIF

The solution is to add/bind Glide artifact with AVIF support

https://github.com/bumptech/glide/issues/5140#issuecomment-1550067008

GPS-FB-MLKit issue:

https://github.com/xamarin/AndroidX/issues/971

## Details

https://mvnrepository.com/artifact/org.aomedia.avif.android/avif

https://repo1.maven.org/maven2/org/aomedia/avif/android/avif/maven-metadata.xml

```xml
<metadata>
    <groupId>org.aomedia.avif.android</groupId>
    <artifactId>avif</artifactId>
    <versioning>
        <latest>1.0.1.262e11d</latest>
        <release>1.0.1.262e11d</release>
        <versions>
            <version>0.9.3.a319893</version>
            <version>0.9.3.545a756</version>
            <version>0.10.1.d22d4de</version>
            <version>0.10.1.e92f734</version>
            <version>0.10.1.2e8fe11</version>
            <version>0.11.1.3c786d2</version>
            <version>0.11.1.647c3c2</version>
            <version>1.0.1.262e11d</version>
        </versions>
        <lastUpdated>20230831222653</lastUpdated>
    </versioning>
</metadata>
```

```
Unhandled exception. System.ArgumentException: '1.0.1.262e11d' is not a valid version string. (Parameter 'value')
   at NuGet.Versioning.NuGetVersion.Parse(String value)
   at MavenNet.MavenVersionRange.Satisfies(String version)
   at MavenNet.Models.Dependency.Satisfies(String version)
   at AndroidBinderator.Engine.<>c__DisplayClass7_0.<BuildProjectModels>b__0(MavenArtifactConfig ma) in C:\a\_work\1\s\util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 343
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at AndroidBinderator.Engine.BuildProjectModels(BindingConfig config, Dictionary`2 mavenProjects) in C:\a\_work\1\s\util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 340
   at AndroidBinderator.Engine.ProcessConfig(BindingConfig config) in C:\a\_work\1\s\util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 75
   at AndroidBinderator.Engine.BinderateAsync(BindingConfig config) in C:\a\_work\1\s\util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 46
   at Xamarin.AndroidBinderator.Tool.Program.Main(String[] args) in C:\a\_work\1\s\util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator.Tool\Program.cs:line 67
   at Xamarin.AndroidBinderator.Tool.Program.<Main>(String[] args)
An error occurred when executing task 'binderate'.
Error: Process xamarin-android-binderator exited with code [134.](url)
```

https://github.com/NuGetArchive/NuGet.Versioning/blob/master/src/NuGet.Versioning/NuGetVersion.cs
